### PR TITLE
Max order comparator

### DIFF
--- a/c_src/antidote.cc
+++ b/c_src/antidote.cc
@@ -68,6 +68,23 @@ namespace leveldb {
                 return (int) sc[0];
             }
 
+            // Given a slice, checks that a list follows, and returns its size.
+            static int checkList(Slice &s) {
+                // LIST_EXT = 108
+                assert(s[0] == (char) 108);
+                s.remove_prefix(1);
+
+                // parse list size
+                unsigned char size[4];
+                size[3] = s[0];
+                size[2] = s[1];
+                size[1] = s[2];
+                size[0] = s[3];
+
+                s.remove_prefix(4);
+                return *(int *)size;
+            }
+
             // No need to shorten keys since it's fixed size.
             virtual void FindShortestSeparator(std::string* start,
                 const Slice& limit) const {

--- a/c_src/antidote.cc
+++ b/c_src/antidote.cc
@@ -110,6 +110,7 @@ namespace leveldb {
                     key = parseInt(s);
                     value = parseInt(s);
                     VC[key] = value;
+                    size--;
                 }
                 return VC;
             }
@@ -146,7 +147,7 @@ namespace leveldb {
             static int compareVCs(map<int, int> a, map<int, int> b) {
                 if (a.size() != b.size()) {
                     // TODO check what to do in this case
-                    return 1;
+                    return -1;
                 }
                 map<int, int>::iterator keyIt;
                 for(map<int, int>::iterator iterator = a.begin();
@@ -154,15 +155,15 @@ namespace leveldb {
                     keyIt = b.find(iterator->first);
                     if(keyIt == b.end()) { // Key sets are !=
                         // TODO check what to do in this case
-                        return 1;
+                        return -1;
                     }
                     if(iterator->second > keyIt->second) {
                         continue;
                     } else {
-                        return -1;
+                        return 1;
                     }
                 }
-                return 1;
+                return -1;
             }
 
             // No need to shorten keys since it's fixed size.

--- a/c_src/antidote.cc
+++ b/c_src/antidote.cc
@@ -135,7 +135,9 @@ namespace leveldb {
                 assert(s[0] == (char) 97 || s[0] == (char) 98);
                 int res;
                 if (s[0] == (char) 97) {
-                    res = (int) s[1];
+                    unsigned char size[1];
+                    size[0] = s[1];
+                    res = *(int *) size;
                     s.remove_prefix(2);
                 } else {
                     unsigned char size[4];

--- a/c_src/antidote.cc
+++ b/c_src/antidote.cc
@@ -1,0 +1,73 @@
+#include <algorithm>
+#include <stdint.h>
+#include "leveldb/comparator.h"
+#include "leveldb/slice.h"
+#include "port/port.h"
+#include "util/logging.h"
+#include <iostream>
+using namespace std;
+
+namespace leveldb {
+
+    //Comparator::~Comparator() { }
+
+    namespace {
+
+        class AntidoteComparator : public Comparator {
+          protected:
+
+          public:
+            AntidoteComparator() { }
+
+            virtual const char* Name() const {
+              return "AntidoteComparator";
+            }
+
+            virtual int Compare(const Slice& a, const Slice& b) const {
+                if(a == b) {
+                    return 0;
+                }
+
+                Slice ac = Slice(a.data());//, bc = Slice(b.data());
+
+                //Slice aname = Get32PrefData(ac), bname = Get32PrefData(bc);
+
+                //int set_cmp = aname.compare(bname);
+
+                cout << ac.ToString() << endl;
+
+                return 1;
+            }
+
+            // No need to shorten keys since it's fixed size.
+            virtual void FindShortestSeparator(std::string* start,
+                const Slice& limit) const {
+            }
+
+            // No need to shorten keys since it's fixed size.
+            virtual void FindShortSuccessor(std::string* key) const {
+            }
+
+
+        };
+
+    }
+
+    static port::OnceType antidote_once = LEVELDB_ONCE_INIT;
+    static const Comparator* antidote_cmp = NULL;
+
+    static void InitAntidoteComparator() {
+      antidote_cmp = new AntidoteComparator();
+    }
+
+    const Comparator* GetAntidoteComparator() {
+      port::InitOnce(&antidote_once, InitAntidoteComparator);
+      return antidote_cmp;
+    }
+
+    void AntidoteComparatorShutdown() {
+        delete antidote_cmp;
+        antidote_cmp = NULL;
+    }
+
+} //namespace antidote

--- a/c_src/antidote.cc
+++ b/c_src/antidote.cc
@@ -262,7 +262,14 @@ namespace leveldb {
                 }
                 // VCs are the same until now
                 // Check if any of them has more keys
-                return sizeComparison(aSize, bSize);
+                int vcSize = sizeComparison(aSize, bSize);
+                if (vcSize != 0) {
+                    return vcSize;
+                } else {
+                    // If the VC is equal, check if it's an op or a snap.
+                    // If this returns 0, the key is identical
+                    return sizeComparison(a.size(), b.size());
+                }
             }
 
             static int sizeComparison(int sizeA, int sizeB) {

--- a/c_src/antidote.cc
+++ b/c_src/antidote.cc
@@ -89,7 +89,17 @@ namespace leveldb {
             static int checkList(Slice &s) {
                 // LIST_EXT = 108
                 assert(s[0] == (char) 108);
-                return parseInt(s);
+                s.remove_prefix(1);
+
+                // parse list size
+                unsigned char size[4];
+                size[3] = s[0];
+                size[2] = s[1];
+                size[1] = s[2];
+                size[0] = s[3];
+
+                s.remove_prefix(4);
+                return *(int *)size;
             }
 
             static map<int, int> parseVCMap(Slice &s, int size) {

--- a/c_src/antidote.cc
+++ b/c_src/antidote.cc
@@ -194,7 +194,7 @@ namespace leveldb {
                     if(keyIt == a.end()) { // Key sets are !=
                         // we return 1 since a doesn't contain that key
                         // an therefore we should treat is as a 0.
-                        return -1;
+                        return 1;
                     }
                     if(iterator->second > keyIt->second) {
                         continue;

--- a/c_src/antidote.cc
+++ b/c_src/antidote.cc
@@ -93,6 +93,12 @@ namespace leveldb {
 
             // Given a slice, checks that a list follows, and returns its size.
             static int checkList(Slice &s) {
+                // NIL_EXT = 106 (Empty list = Empty Snapshot)
+                if(s[0] == (char) 106) {
+                    s.remove_prefix(1);
+                    return 0;
+                }
+
                 // LIST_EXT = 108
                 assert(s[0] == (char) 108);
                 s.remove_prefix(1);

--- a/c_src/antidote.cc
+++ b/c_src/antidote.cc
@@ -189,12 +189,13 @@ namespace leveldb {
                     s.remove_prefix(5);
                     intSize = *(int *) size;
                 }
-                // Clock time can't be negative, therfore this byte must be 0 
+                // Clock time can't be negative, therfore this byte must be 0
                 assert((int) s[0] == 0);
                 s.remove_prefix(1);
                 unsigned char current[1];
                 int originalSize = intSize;
                 while (intSize > 0) {
+                    current[0] = s[0];
                     res += ((*(int *) current) * power(256, originalSize - intSize));
                     s.remove_prefix(1);
                     intSize--;
@@ -203,13 +204,10 @@ namespace leveldb {
             }
 
             static unsigned long long int power(unsigned long long int base, int exp) {
-                unsigned long long int result = 1ULL;
+                unsigned long long int result = 1;
                 while(exp > 0) {
-                    if (exp & 1) {
-                        result *= (unsigned long long int) base;
-                    }
-                    exp >>= 1;
-                    base *= base;
+                    result *= base;
+                    exp--;
                 }
                 return result;
             }

--- a/c_src/antidote.cc
+++ b/c_src/antidote.cc
@@ -106,11 +106,21 @@ namespace leveldb {
                 map<int, int> VC;
                 int key, value;
                 while(size > 0) {
+                    checkTwoElementTuple(s);
                     key = parseInt(s);
                     value = parseInt(s);
                     VC[key] = value;
                 }
                 return VC;
+            }
+
+            static void checkTwoElementTuple(Slice &s) {
+                // SMALL_TUPLE_EXT == 104
+                assert(s[0] == (char) 104);
+                s.remove_prefix(1);
+                // LENGTH == 2 (DC, clock)
+                assert(s[0] == (char) 2);
+                s.remove_prefix(1);
             }
 
             // Given a Slice parses a SMALL_INTEGER_EXT (97) or INTEGER_EXT (98)

--- a/c_src/antidote.cc
+++ b/c_src/antidote.cc
@@ -42,6 +42,12 @@ namespace leveldb {
 
                 if(key_compare) {
                     return key_compare;
+                } else {
+                    // If we are supplied with a key that only contains
+                    // the antidote key, we can't continue parsing, therefore
+                    // return -1 or 1 according to which key is the shorter.
+                    if ((ac.size() - aKeySize) == 0) return -1;
+                    if ((bc.size() - bKeySize) == 0) return 1;
                 }
 
                 // If keys are equal, continue with the vector clock

--- a/c_src/antidote.cc
+++ b/c_src/antidote.cc
@@ -28,7 +28,7 @@ namespace leveldb {
                     return 0;
                 }
 
-                Slice ac = Slice(a.data()), bc = Slice(b.data());
+                Slice ac = Slice(a.data(), a.size()), bc = Slice(b.data(), b.size());
 
                 // Trim Slices and compare Antidote keys (atoms)
                 int aKeySize = checkAndTrimFirstBytes(ac);

--- a/c_src/antidote.cc
+++ b/c_src/antidote.cc
@@ -151,16 +151,13 @@ namespace leveldb {
             }
 
             static int compareVCs(map<int, int> a, map<int, int> b) {
-                if (a.size() != b.size()) {
-                    // TODO check what to do in this case
-                    return -1;
-                }
                 map<int, int>::iterator keyIt;
-                for(map<int, int>::iterator iterator = a.begin();
-                                iterator != a.end(); iterator++) {
-                    keyIt = b.find(iterator->first);
-                    if(keyIt == b.end()) { // Key sets are !=
-                        // TODO check what to do in this case
+                for(map<int, int>::iterator iterator = b.begin();
+                                iterator != b.end(); iterator++) {
+                    keyIt = a.find(iterator->first);
+                    if(keyIt == a.end()) { // Key sets are !=
+                        // we return -1 since a doesn't contain that key
+                        // an therefore we should treat is as a 0.
                         return -1;
                     }
                     if(iterator->second > keyIt->second) {

--- a/c_src/antidote.cc
+++ b/c_src/antidote.cc
@@ -239,25 +239,18 @@ namespace leveldb {
                     valueA = parseInt(a);
                     valueB = parseInt(b);
 
-                    // Keys are sorted, so we leverage that
-                    if(keyA.compare(keyB) == 0) {
-                        // Same key
-                        if(valueB == valueA) {
-                            // Values for this key are equal,
-                            // continue to next key
-                            aSize--;
-                            bSize--;
-                            continue;
-                        }
-                        // Values are different, so return the comparison
-                        if(valueB > valueA) {
-                            return 1;
-                        } else {
-                            return -1;
-                        }
+                    if(valueB == valueA) {
+                        // Values for this key are equal,
+                        // continue to next key
+                        aSize--;
+                        bSize--;
+                        continue;
+                    }
+                    // Values are different, so return the comparison
+                    if(valueB > valueA) {
+                        return 1;
                     } else {
-                        // Key is different so return the comparison
-                        return keyA.compare(keyB);
+                        return -1;
                     }
                 }
                 // VCs are the same until now
@@ -265,10 +258,18 @@ namespace leveldb {
                 int vcSize = sizeComparison(aSize, bSize);
                 if (vcSize != 0) {
                     return vcSize;
+                }
+
+                // If VCs are equal, compare Hashes and op/snap
+                // Usint the Slice compare method
+                return -1 * a.compare(b);
+            }
+
+            static int hashComparison(int hashA, int hashB) {
+                if(hashB > hashA) {
+                    return 1;
                 } else {
-                    // If the VC is equal, check if it's an op or a snap.
-                    // If this returns 0, the key is identical
-                    return sizeComparison(a.size(), b.size());
+                    return -1;
                 }
             }
 

--- a/c_src/antidote.cc
+++ b/c_src/antidote.cc
@@ -150,23 +150,33 @@ namespace leveldb {
                 return res;
             }
 
+            // This method returns -1 * the comparison value, since
+            // we are sorting keys from oldest to newest first.
             static int compareVCs(map<int, int> a, map<int, int> b) {
+                if (a.size() > b.size()) {
+                    // a is "newer" since it contains more keys.
+                    return -1;
+                }
+                if (a.size() < b.size()) {
+                    // b is "newer" since it contains more keys.
+                    return 1;
+                }
                 map<int, int>::iterator keyIt;
                 for(map<int, int>::iterator iterator = b.begin();
                                 iterator != b.end(); iterator++) {
                     keyIt = a.find(iterator->first);
                     if(keyIt == a.end()) { // Key sets are !=
-                        // we return -1 since a doesn't contain that key
+                        // we return 1 since a doesn't contain that key
                         // an therefore we should treat is as a 0.
                         return -1;
                     }
                     if(iterator->second > keyIt->second) {
                         continue;
                     } else {
-                        return 1;
+                        return -1;
                     }
                 }
-                return -1;
+                return 1;
             }
 
             // No need to shorten keys since it's fixed size.

--- a/c_src/antidote.cc
+++ b/c_src/antidote.cc
@@ -37,7 +37,19 @@ namespace leveldb {
                 Slice aKey = Slice(ac.data(), aKeySize);
                 Slice bKey = Slice(bc.data(), bKeySize);
 
-                return aKey.compare(bKey);
+                int key_compare = aKey.compare(bKey);
+
+                if(key_compare) {
+                    return key_compare;
+                }
+
+                // If keys are equal, continue with the vector clock
+                // First trim the key
+                ac.remove_prefix(aKeySize);
+                bc.remove_prefix(bKeySize);
+
+                //return 1 for now
+                return 1;
             }
 
             // Given a slice, checks that the first bytes match Erlang

--- a/c_src/antidote.cc
+++ b/c_src/antidote.cc
@@ -189,8 +189,8 @@ namespace leveldb {
                     s.remove_prefix(5);
                     intSize = *(int *) size;
                 }
-                // Clock time can't be negative
-                assert(s[0] == (char) 48);
+                // Clock time can't be negative, therfore this byte must be 0 
+                assert((int) s[0] == 0);
                 s.remove_prefix(1);
                 unsigned char current[1];
                 int originalSize = intSize;

--- a/c_src/antidote.h
+++ b/c_src/antidote.h
@@ -1,0 +1,11 @@
+#ifndef ANTIDOTE_COMPARATOR_H_
+#define ANTIDOTE_COMPARATOR_H_
+
+#include "leveldb/comparator.h"
+
+namespace leveldb {
+
+    extern const Comparator* GetAntidoteComparator();
+}
+
+#endif

--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -452,15 +452,14 @@ ERL_NIF_TERM parse_open_option(ErlNifEnv* env, ERL_NIF_TERM item, leveldb::Optio
             if (0<ret_val && ret_val<256)
                 opts.tiered_slow_prefix = buffer;
         }
-
-    }
-    else if (option[0] == eleveldb::ATOM_ANTIDOTE)
+        else if (option[0] == eleveldb::ATOM_ANTIDOTE)
         {
           if (option[1] == eleveldb::ATOM_TRUE)
             {
               opts.comparator = leveldb::GetAntidoteComparator();
             }
         }
+    }
 
     return eleveldb::ATOM_OK;
 }

--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -33,6 +33,7 @@
 #include <vector>
 
 #include "eleveldb.h"
+#include "antidote.h"
 
 #include "leveldb/db.h"
 #include "leveldb/comparator.h"
@@ -132,6 +133,7 @@ ERL_NIF_TERM ATOM_DELETE_THRESHOLD;
 ERL_NIF_TERM ATOM_TIERED_SLOW_LEVEL;
 ERL_NIF_TERM ATOM_TIERED_FAST_PREFIX;
 ERL_NIF_TERM ATOM_TIERED_SLOW_PREFIX;
+ERL_NIF_TERM ATOM_ANTIDOTE;
 }   // namespace eleveldb
 
 
@@ -452,6 +454,13 @@ ERL_NIF_TERM parse_open_option(ErlNifEnv* env, ERL_NIF_TERM item, leveldb::Optio
         }
 
     }
+    else if (option[0] == eleveldb::ATOM_ANTIDOTE)
+        {
+          if (option[1] == eleveldb::ATOM_TRUE)
+            {
+              opts.comparator = leveldb::GetAntidoteComparator();
+            }
+        }
 
     return eleveldb::ATOM_OK;
 }
@@ -1260,6 +1269,7 @@ try
     ATOM(eleveldb::ATOM_TIERED_SLOW_LEVEL, "tiered_slow_level");
     ATOM(eleveldb::ATOM_TIERED_FAST_PREFIX, "tiered_fast_prefix");
     ATOM(eleveldb::ATOM_TIERED_SLOW_PREFIX, "tiered_slow_prefix");
+    ATOM(eleveldb::ATOM_ANTIDOTE, "antidote");
 #undef ATOM
 
 

--- a/src/eleveldb.erl
+++ b/src/eleveldb.erl
@@ -102,7 +102,8 @@ init() ->
                          {delete_threshold, pos_integer()} |
                          {tiered_slow_level, pos_integer()} |
                          {tiered_fast_prefix, string()} |
-                         {tiered_slow_prefix, string()}].
+                         {tiered_slow_prefix, string()} |
+                         {antidote, boolean()}].
 
 -type read_options() :: [{verify_checksums, boolean()} |
                          {fill_cache, boolean()} |


### PR DESCRIPTION
The new logging and caching module for antidote, will use eleveldb as one of its possible backends. In order to use eleveldb, we needed to code a new comparator, so keys get sorted as we want.

Keys are composed as follows:

`{antidote_key, max_value_in_vc, vc_hash, op/snap, vc}`
- **antidote_key**: Same key as in Antidote. 
- **max_value_in_vc**: The max value for all DCs in the VC.
- **vc_hash**: A hash of the VC. This is done in order to provide a more performant sorting algorithm, since we don't need to compare all the VC, to find that keys are different. If the hash matches, we also compare the VC, just to make sure it's not a collision. 
- **op/snap**: an atom indicating if the stored value corresponds to an operation or a snapshot.
- **vc**: the vc of when the op/snap ocurred.

**Sorting of keys**

Keys get sorted first by the Antidote key.
Then we look at the MAX value of it's VC, sorting first the biggest one. We reverse the "natural" order, so we can have the most recent operations first.
If the max value for two keys matches, we sort taking into account the hash value.
For matching hashes, we check the rest of the key, sorting accordingly.

As Erlang serialises objects sent to eleveldb, according http://erlang.org/doc/apps/erts/erl_ext_dist.html, so what we do is check those code to compare keys.
